### PR TITLE
Changing hackney timeout because stories request is taking too long to respond

### DIFF
--- a/apps/clubhousex/lib/clubhousex.ex
+++ b/apps/clubhousex/lib/clubhousex.ex
@@ -1,7 +1,7 @@
 defmodule Clubhousex do
   use Tesla
 
-  adapter(Tesla.Adapter.Hackney, recv_timeout: 30_000)
+  adapter(Tesla.Adapter.Hackney, recv_timeout: 90_000)
 
   plug(Tesla.Middleware.JSON)
   plug(Tesla.Middleware.BaseUrl, "https://api.clubhouse.io/api/v3")


### PR DESCRIPTION
## Context
Changing hackney timeout because stories request is taking too long to respond.

This endpoint has not pagination.